### PR TITLE
ログの出力内容を heroku logs にあわせる

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -21,7 +21,9 @@ class App
     lines = if LOG_REQUEST_URI
       [env['REQUEST_URI']]
     else
-      HerokuLogParser.parse(env['rack.input'].read).collect {|m| m[:message] }
+      HerokuLogParser.parse(env['rack.input'].read).collect { |m|
+        "#{m[:emitted_at] m[:hostname]\[m[:proc_id]\]: m[:message]}"
+      }
     end
 
     lines.each do |line|


### PR DESCRIPTION
s3に転送されるログがmessageだけなので、タイムスタンプとかを含めて、 `heroku logs` の出力内容にあわせる。