### PR TITLE
upgrade ruby to 2.7.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Setup the following `ENV` (aka `heroku config:set`)
 
 - `FILTER_PREFIX` this is the prefix string to look out for. every other log lines are ignored
 - `S3_KEY`, `S3_SECRET`, `S3_BUCKET` necessary ACL to your s3 bucket
+- `AWS_REGION` the AWS region your S3 bucket is in
 - `DURATION` (default `60`) seconds to buffer until we close the `IO` to `AWS::S3::S3Object#write`
 - `STRFTIME` (default `%Y%m/%d/%H/%M%S.:thread_id.log`) format of your s3 `object_id`
   - `:thread_id` will be replaced by a unique number to prevent overwriting of the same file between reboots, in case the timestamp overlaps

--- a/app.json
+++ b/app.json
@@ -4,6 +4,7 @@
   "repository": "https://github.com/choonkeat/heroku-log-s3",
   "keywords": ["ruby", "rack", "log", "drain", "s3", "upload"],
   "env": {
+    "AWS_REGION": "",
     "S3_KEY": "",
     "S3_SECRET": "",
     "S3_BUCKET": "",


### PR DESCRIPTION
Hi there. Thanks for this. I was deploying this today and heroku cedar 20 wouldn't accept the 2.7.0 version of ruby. The deployment would fail.